### PR TITLE
Don't remove whitespaces for maintainer name

### DIFF
--- a/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/__init__.py
@@ -2,7 +2,7 @@
 
 __version__ = '{{ cookiecutter.package_version }}'
 __author__ = '{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>'
-{%- if cookiecutter.maintainer_name -%}
+{%- if cookiecutter.maintainer_name %}
 __maintainer__ = '{{ cookiecutter.maintainer_name }} <{{ cookiecutter.maintainer_email }}>'
 {%- endif %}
 __all__ = []


### PR DESCRIPTION
This leads to the output to be formatted like this:

    __author__ = 'abc'__maintainer__ = 'xyz'

which is a syntax error