### PR TITLE
Remove maintainer_name and maintainer_email

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,9 +2,6 @@
     "author_name": "Sam Clements",
     "author_email": "sam@borntyping.co.uk",
 
-    "maintainer_name": null,
-    "maintainer_email": null,
-
     "package_name": "cookiecutter-pypackage-minimal",
     "package_version": "0.1.0",
     "package_description": "An opinionated, minimal cookiecutter template for Python packages",

--- a/{{cookiecutter.package_name}}/README.rst
+++ b/{{cookiecutter.package_name}}/README.rst
@@ -34,6 +34,3 @@ Authors
 -------
 
 `{{ cookiecutter.package_name }}` was written by `{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>`_.
-{% if cookiecutter.maintainer_name -%}
-`{{ cookiecutter.package_name }}` was written by `{{ cookiecutter.maintainer_name }} <{{ cookiecutter.maintainer_email }}>`_.
-{%- endif %}

--- a/{{cookiecutter.package_name}}/setup.py
+++ b/{{cookiecutter.package_name}}/setup.py
@@ -8,11 +8,6 @@ setuptools.setup(
     author="{{ cookiecutter.author_name }}",
     author_email="{{ cookiecutter.author_email }}",
 
-    {%- if cookiecutter.maintainer_name -%}
-    maintainer="{{ cookiecutter.maintainer_name }}",
-    maintainer_email="{{ cookiecutter.maintainer_email }}",
-    {%- endif %}
-
     description="{{ cookiecutter.package_description }}",
     long_description=open('README.rst').read(),
 

--- a/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/__init__.py
@@ -2,7 +2,4 @@
 
 __version__ = '{{ cookiecutter.package_version }}'
 __author__ = '{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>'
-{%- if cookiecutter.maintainer_name %}
-__maintainer__ = '{{ cookiecutter.maintainer_name }} <{{ cookiecutter.maintainer_email }}>'
-{%- endif %}
 __all__ = []


### PR DESCRIPTION
The current default of having a dedicated option for the maintainer is a
bit annoying:

  - If someone is using a cookiecutter template, they are most likely
    starting a new project, which means they are both the author and the
    maintainer. In this case, only author needs to be set.

  - The current default of null doesn't entirely work, and you're left
    with things like `__maintainer__ = 'None <None>'` in a few places.
    Having to remove these by hand is a little tedious.

To keep with the minimalism, this commit just removes the option to set
maintainer_name and maintainer_email.